### PR TITLE
feat: enforce linting in CI workflows

### DIFF
--- a/.github/workflows/.tests.yml
+++ b/.github/workflows/.tests.yml
@@ -35,7 +35,9 @@ jobs:
           NODE_ENV: unittest
         with:
           commands: |
+            cd .. && npm ci
             npm ci
+            npm run lint
             npm run test:cov
           dir: backend
           node_version: "22"
@@ -60,7 +62,9 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FRONTEND }}
         with:
           commands: |
+            cd .. && npm ci
             npm ci
+            npm run lint
             npm run test:cov
           dir: frontend
           node_version: "22"

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -11,6 +11,7 @@ export default [
       ...baseIgnores,
       "**/*.config.*",
       "**/routeTree.gen.ts",
+      "e2e/**",
     ],
   },
   {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,8 @@
     "test:unit": "vitest --mode test",
     "test:cov": "vitest run --mode test --coverage",
     "build": "vite build",
-    "lint": "eslint \"src/**/*.{ts,tsx}\" \"e2e/**/*.ts\"",
-    "lint:fix": "eslint \"src/**/*.{ts,tsx}\" \"e2e/**/*.ts\" --fix"
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix"
   },
   "dependencies": {
     "@bcgov/bc-sans": "^2.1.0",


### PR DESCRIPTION
## Description

This PR integrates ESLint linting into the existing CI test jobs, ensuring code quality checks run on every PR.

## Changes

- **CI Integration**: Added linting step to backend-tests and frontend-tests jobs in `.github/workflows/.tests.yml`
  - Install root dependencies before linting (required for `eslint-base.config.mjs` module resolution)
  - Run `npm run lint` before tests in both backend and frontend jobs
- **Config**: Updated `frontend/eslint.config.mjs` to exclude `e2e/**` directory from linting (not in tsconfig.json project scope)
- **Scripts**: Updated `frontend/package.json` to remove `e2e/**` from lint scripts

## Type of change

- [x] New feature (CI linting enforcement)

## Benefits

- Linting errors caught before merge
- Consistent code quality across PRs
- Prevents broken code from entering main branch
- Minimal overhead (linting runs as part of test jobs)

## Testing

- CI workflows updated to include lint checks
- Linting will run on every PR and must pass before merge

## Related

Final PR (Phase 4) in ESLint migration plan. Completes the full migration from legacy ESLint to modern ESLint 9 flat config with CI enforcement.

---

**Note:** This PR contains only linting configuration changes (CI workflow, ESLint config, package.json scripts). No code changes or lint fixes are included.