### PR TITLE
fix: SSL_MODE constant condition bug and test improvements

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,7 @@
     "make-badges": "istanbul-badges-readme --logo=vitest --exitCode=1",
     "make-badges:ci": "npm run make-badges -- --ci",
     "test": "vitest --dir src",
-    "test:cov": "prisma generate && vitest run --coverage",
+    "test:cov": "prisma generate && vitest run --coverage --dir src",
     "test:e2e": "vitest --dir test"
   },
   "dependencies": {

--- a/backend/src/middleware/req.res.logger.spec.ts
+++ b/backend/src/middleware/req.res.logger.spec.ts
@@ -12,7 +12,6 @@ describe("HTTPLoggerMiddleware", () => {
     }).compile();
 
     middleware = module.get<HTTPLoggerMiddleware>(HTTPLoggerMiddleware);
-    logger = module.get<Logger>(Logger);
   });
   it("should log the correct information", () => {
     const request: Request = {

--- a/backend/src/prisma.service.ts
+++ b/backend/src/prisma.service.ts
@@ -16,7 +16,9 @@ const DB_SCHEMA = process.env.POSTGRES_SCHEMA || "app";
 const DB_POOL_SIZE = parseInt(process.env.POSTGRES_POOL_SIZE || "5", 10);
 // SSL settings for PostgreSQL 17+ which requires SSL by default
 const SSL_MODE =
-  process.env.NODE_ENV === "local" || "unittest" ? "prefer" : "require"; // 'require' for aws deployments, 'prefer' for local development or ut in gha
+  (process.env.NODE_ENV === "local" || process.env.NODE_ENV === "unittest")
+    ? "prefer"
+    : "require"; // 'require' for aws deployments, 'prefer' for local development or ut in gha
 const dataSourceURL = `postgresql://${DB_USER}:${DB_PWD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?schema=${DB_SCHEMA}&connection_limit=${DB_POOL_SIZE}&sslmode=${SSL_MODE}`;
 
 @Injectable({ scope: Scope.DEFAULT })

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -2,17 +2,53 @@ import request from "supertest";
 import { Test } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
 import { AppModule } from "../src/app.module";
+import { PrismaService } from "../src/prisma.service";
 
 describe("AppController (e2e)", () => {
   let app: INestApplication;
 
   beforeAll(async () => {
+    // Create a proper mock that implements the required PrismaService interface
+    const mockPrismaService = {
+      onModuleInit: async () => {
+        // Mock implementation - no database connection needed
+        return Promise.resolve();
+      },
+      onModuleDestroy: async () => {
+        // Mock implementation - no cleanup needed
+        return Promise.resolve();
+      },
+      $connect: async () => {
+        // Mock $connect to prevent database connection
+        return Promise.resolve();
+      },
+      $disconnect: async () => {
+        // Mock $disconnect
+        return Promise.resolve();
+      },
+      $on: () => {
+        // Mock $on event listener
+      },
+      // Add any other PrismaClient methods that might be accessed
+      $transaction: async () => Promise.resolve([]),
+      $use: () => {},
+      $extends: () => mockPrismaService,
+    };
+
+    // Override PrismaService to use mock instead of real database connection
     const moduleFixture = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      .overrideProvider(PrismaService)
+      .useValue(mockPrismaService as unknown as PrismaService)
+      .compile();
 
     app = moduleFixture.createNestApplication();
     await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
   });
 
   it("/ (GET)", () =>


### PR DESCRIPTION
## Description

This PR fixes the critical SSL_MODE bug that was incorrectly fixed in PR #211, and improves test configuration without modifying production code for test purposes.

## The Bug

The original buggy code in `backend/src/prisma.service.ts`:
```typescript
const SSL_MODE = process.env.NODE_ENV === 'local' || 'unittest' ? 'prefer' : 'require';
```

This always evaluated to `'prefer'` because `'unittest'` is a non-empty string (truthy), causing **production deployments to incorrectly use sslmode=prefer instead of sslmode=require**.

## The Fix

Fixed the logical expression to properly check both conditions:
```typescript
const SSL_MODE = (process.env.NODE_ENV === 'local' || process.env.NODE_ENV === 'unittest') ? 'prefer' : 'require';
```

## Changes

- **Fixed SSL_MODE bug**: Corrected logical expression in `backend/src/prisma.service.ts`
- **E2E test improvements**: Added PrismaService mock in `backend/test/app.e2e-spec.ts` without modifying production code
- **Test configuration**: Updated `test:cov` to exclude e2e tests using `--dir src`
- **Test fix**: Removed unused logger variable assignment in `backend/src/middleware/req.res.logger.spec.ts` (leftover from previous PR)

## Key Difference from PR #211

Unlike PR #211, this PR:
- ✅ Fixes the SSL_MODE bug correctly
- ✅ Does NOT modify production code to suit tests
- ✅ Uses proper mocking in test files only
- ✅ Maintains clean separation between production and test code

## Testing

- ✅ All unit tests pass (`npm run test:cov`)
- ✅ E2E tests properly mock PrismaService without database connection
- ✅ Production code remains unchanged for test purposes

## Type of Change

- Bug fix (critical SSL_MODE configuration bug)
- Test improvements